### PR TITLE
Align Node version across CI and dev

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM n8nio/base:20
+FROM n8nio/base:20.15
 
 RUN apk add --no-cache --update openssh sudo shadow bash
 RUN echo node ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/node && chmod 0440 /etc/sudoers.d/node

--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -5,7 +5,7 @@ inputs:
   node-version:
     description: 'Node.js version to use.'
     required: false
-    default: '22.x'
+    default: '20.15'
   enable-caching:
     description: Flag to enable/disable all caching (pnpm store, Turborepo, and dist folders).'
     required: false

--- a/.github/workflows/e2e-tests-pr.yml
+++ b/.github/workflows/e2e-tests-pr.yml
@@ -45,7 +45,7 @@ jobs:
       should_run: ${{ steps.changed.outputs.not_ignored == 'true' && !contains(github.event.pull_request.labels.*.name, 'community') && (github.event.pull_request.base.ref == 'master' || startsWith(github.event.pull_request.base.ref, 'release/')) }}
 
   run-e2e-tests:
-    name: E2E [Electron/Node 18]
+    name: E2E [Electron/Node 20]
     uses: ./.github/workflows/e2e-reusable.yml
     needs: [get-metadata]
     if: ${{ github.event.review.state == 'approved' && needs.get-metadata.outputs.should_run == 'true' }}
@@ -57,7 +57,7 @@ jobs:
 
   post-e2e-tests:
     runs-on: ubuntu-latest
-    name: E2E [Electron/Node 18] - Checks
+    name: E2E [Electron/Node 20] - Checks
     needs: [get-metadata, run-e2e-tests]
     if: always()
     steps:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -40,7 +40,7 @@ jobs:
         shell: bash
 
   run-e2e-tests:
-    name: E2E [Electron/Node 18]
+    name: E2E [Electron/Node 20]
     uses: ./.github/workflows/e2e-reusable.yml
     with:
       branch: ${{ github.event.inputs.branch || 'master' }}


### PR DESCRIPTION
## Summary
- update CI job names for Node 20
- default setup action to Node `20.15`
- build dev container with `n8nio/base:20.15`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684115e9e2ec8327a674dd77fbcbbcea